### PR TITLE
DS-3723, DS-3351: Update GitHub Actions to fix deprecations.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,13 @@ runs:
       shell: bash
       run: |
         if [ ${{ inputs.from-version }} == ${{ inputs.to-version }} ] ; then
-          echo "::set-output name=changed::false"
+          echo "changed=false" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
         fi
     - name: Checkout target repository with history
       if: ${{ steps.changed.outputs.changed == 'true'  }}
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         path: target-repository
@@ -76,7 +76,7 @@ runs:
         # Changes PR-number strings like '(#100)' into '(owner/repository#100)'.
         log=$(echo $log | sed -r 's|\(#([0-9]+)\)|(${{ inputs.repository }}#\1)|g')
         
-        echo "::set-output name=changelog::${log}"
+        echo "changelog=${log}" >> $GITHUB_OUTPUT
     - name: Cleanup
       if: ${{ steps.changed.outputs.changed == 'true'  }}
       shell: bash


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

This fixes the NodeJS 12 deprecation warnings and set-output command warnings.

More at 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

