### PR TITLE
Escape quotes in changelog

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ runs:
         log+=$(git log "${from}..${to}" \
             --pretty=format:"- [%h](http://github.com/${{ inputs.repository }}/commit/%H) - %s (%aN)")
 
+        log="${log//'`'/'\`'}"
+        log="${log//'"'/'\"'}"
+        log="${log//'%'/'%25'}"
+
         # Add full repository qualifier to PR references.
         # Changes PR-number strings like '(#100)' into '(owner/repository#100)'.
         log=$(echo "$log" | sed -r 's|\(#([0-9]+)\)|(${{ inputs.repository }}#\1)|g')


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes an issue which caused PR creation to fail because the changelog string contained double quote

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

